### PR TITLE
fix dark mode being applied to non-pdf page

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -5,8 +5,7 @@
 
 // set status to active initially
 chrome.storage.sync.get("active", ({ active }) => {
-  if (typeof active === 'undefined')
-    chrome.storage.sync.set({ active: true });
+  if (typeof active === "undefined") chrome.storage.sync.set({ active: true });
 });
 
 // set strength to max initially
@@ -24,8 +23,9 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   if (!changeInfo.status === "complete") {
     return;
   }
-  // apply dark mode if viewing PDF
-  if (tab.url && (tab.url.includes(".pdf") || tab.url.includes(".PDF"))) {
+
+  const extension = tab.url.slice(-4);
+  if (tab.url && (extension === ".pdf" || extension === ".PDF")) {
     if (tabId)
       chrome.scripting.executeScript({
         target: { tabId: tabId },


### PR DESCRIPTION
# Description
Currently, the dark mode is being applied to non-pdf pages. This Pull Request updates dark mode to be applied only on pdf files.

## Type of change
- [x] Bug Fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
By testing in different pdf files

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings